### PR TITLE
fix bug

### DIFF
--- a/datasize.go
+++ b/datasize.go
@@ -190,7 +190,7 @@ ParseLoop:
 		}
 		val *= uint64(PB)
 
-	case "E", "EB", "eib", "e", "eb", "eB":
+	case "e", "eb", "eib", "exa", "exabyte", "exabytes":
 		if val > maxUint64/uint64(EB) {
 			goto Overflow
 		}

--- a/datasize.go
+++ b/datasize.go
@@ -160,37 +160,37 @@ ParseLoop:
 	case "", "b", "byte":
 		// do nothing - already in bytes
 
-	case "k", "kb", "kilo", "kilobyte", "kilobytes":
+	case "k", "kb", "kib", "kilo", "kilobyte", "kilobytes":
 		if val > maxUint64/uint64(KB) {
 			goto Overflow
 		}
 		val *= uint64(KB)
 
-	case "m", "mb", "mega", "megabyte", "megabytes":
+	case "m", "mb", "mib", "mega", "megabyte", "megabytes":
 		if val > maxUint64/uint64(MB) {
 			goto Overflow
 		}
 		val *= uint64(MB)
 
-	case "g", "gb", "giga", "gigabyte", "gigabytes":
+	case "g", "gb", "gib", "giga", "gigabyte", "gigabytes":
 		if val > maxUint64/uint64(GB) {
 			goto Overflow
 		}
 		val *= uint64(GB)
 
-	case "t", "tb", "tera", "terabyte", "terabytes":
+	case "t", "tb", "tib", "tera", "terabyte", "terabytes":
 		if val > maxUint64/uint64(TB) {
 			goto Overflow
 		}
 		val *= uint64(TB)
 
-	case "p", "pb", "peta", "petabyte", "petabytes":
+	case "p", "pb", "pib", "peta", "petabyte", "petabytes":
 		if val > maxUint64/uint64(PB) {
 			goto Overflow
 		}
 		val *= uint64(PB)
 
-	case "E", "EB", "e", "eb", "eB":
+	case "E", "EB", "eib", "e", "eb", "eB":
 		if val > maxUint64/uint64(EB) {
 			goto Overflow
 		}


### PR DESCRIPTION
```
/root/go/pkg/mod/github.com/c2h5oh/datasize@v0.0.0-20220606134207-859f65c6625b/datasize.go:193:18: duplicate case "e" (constant of type string) in expression switch
	/root/go/pkg/mod/github.com/c2h5oh/datasize@v0.0.0-20220606134207-859f65c6625b/datasize.go:193:7: previous case
/root/go/pkg/mod/github.com/c2h5oh/datasize@v0.0.0-20220606134207-859f65c6625b/datasize.go:193:23: duplicate case "eb" (constant of type string) in expression switch
	/root/go/pkg/mod/github.com/c2h5oh/datasize@v0.0.0-20220606134207-859f65c6625b/datasize.go:193:12: previous case
```