### PR TITLE
Add ParseAs and ParseStringAs functions

### DIFF
--- a/datasize.go
+++ b/datasize.go
@@ -237,3 +237,32 @@ func ParseString(s string) (ByteSize, error) {
 func MustParseString(s string) ByteSize {
 	return MustParse([]byte(s))
 }
+
+// ParseStringAs decodes given size with different base unit.
+// If a given size is a simple number (uint64) without a unit, then the given base unit is used,
+// otherwise the Parse function is used.
+func ParseStringAs(s string, base ByteSize) (ByteSize, error) {
+	if n, err := strconv.ParseUint(s, 10, 64); err == nil {
+		return ByteSize(n) * base, nil
+	}
+	return Parse([]byte(s))
+}
+
+func MustParseStringAs(s string, base ByteSize) ByteSize {
+	v, err := ParseStringAs(s, base)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// ParseAs decodes given size with different base unit.
+// If a given size is a simple number (uint64) without a unit, then the given base unit is used,
+// otherwise it behaves as Parse function.
+func ParseAs(t []byte, base ByteSize) (ByteSize, error) {
+	return ParseStringAs(string(t), base)
+}
+
+func MustParseAs(t []byte, base ByteSize) ByteSize {
+	return MustParseStringAs(string(t), base)
+}

--- a/datasize_test.go
+++ b/datasize_test.go
@@ -119,3 +119,63 @@ func TestUnmarshalText(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAs(t *testing.T) {
+	for _, tt := range []ByteSize{B, KB, MB, GB, TB, PB, EB} {
+		name := tt.String()[1:]
+		value := "42"
+		expected := 42 * tt
+		t.Run(name, func(t *testing.T) {
+			t.Run("ParseAs", func(t *testing.T) {
+				s, err := ParseAs([]byte(value), tt)
+				t.Log(s)
+
+				if err != nil {
+					t.Errorf("ParseAs(42, %s)) => %v, want no error", name, err)
+				}
+
+				if s != expected {
+					t.Errorf("Parse(42, %s) => %d bytes, want %d bytes", name, s, 42*expected)
+				}
+			})
+			t.Run("MustParseAs", func(t *testing.T) {
+				defer func() {
+					if err := recover(); err != nil {
+						t.Errorf("ParseAs(42, %s)) => %v, want no error", name, err)
+					}
+				}()
+
+				s := MustParseAs([]byte(value), tt)
+				t.Log(s)
+				if s != expected {
+					t.Errorf("Parse(42, %s) => %d bytes, want %d bytes", name, s, 42*expected)
+				}
+			})
+			t.Run("ParseStringAs", func(t *testing.T) {
+				s, err := ParseStringAs(value, tt)
+				t.Log(s)
+
+				if err != nil {
+					t.Errorf("ParseAs(42, %s)) => %v, want no error", name, err)
+				}
+
+				if s != expected {
+					t.Errorf("Parse(42, %s) => %d bytes, want %d bytes", name, s, 42*expected)
+				}
+			})
+			t.Run("MustParseStringAs", func(t *testing.T) {
+				defer func() {
+					if err := recover(); err != nil {
+						t.Errorf("ParseAs(42, %s)) => %v, want no error", name, err)
+					}
+				}()
+
+				s := MustParseStringAs(value, tt)
+				t.Log(s)
+				if s != expected {
+					t.Errorf("Parse(42, %s) => %d bytes, want %d bytes", name, s, 42*expected)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
Sometimes we want to use a different unit as base. We have an API that returns a link to download a file instead of returnning it as the responses if the size of the file is greater than given limit: `GET  /v1/data/<id>?limit=20`
and we want to let a user to use just a number without any units and parse it as megabytes, not as bytes.

To solve this I have created a simple helper and want to contribute it back to upstream, maybe it can be useful to anyone else. The helper just uses strconv.ParseUint to validate that the given size can be parsed as Uint64 and then multiplies it to given base, if no then just uses dafault Parser fucntion.